### PR TITLE
Add "drag" method

### DIFF
--- a/pymouse/base.py
+++ b/pymouse/base.py
@@ -59,6 +59,12 @@ class PyMouseMeta(object):
 
         raise NotImplementedError
 
+    def drag(self, x, y):
+        """Drag the mouse to a given x and y.
+        A Drag is a Move where the mouse key is held down."""
+
+        raise NotImplementedError
+
     def position(self):
         """Get the current mouse position in pixels.
         Returns a tuple of 2 integers"""

--- a/pymouse/mac.py
+++ b/pymouse/mac.py
@@ -32,7 +32,10 @@ class PyMouse(PyMouseMeta):
     def move(self, x, y):
         move = CGEventCreateMouseEvent(None, kCGEventMouseMoved, (x, y), 0)
         CGEventPost(kCGHIDEventTap, move)
-        
+
+    def drag(self, x, y):        
+        drag = CGEventCreateMouseEvent(None, kCGEventLeftMouseDragged, (x, y), 0)
+        CGEventPost(kCGHIDEventTap, drag)
 
     def position(self):
         loc = NSEvent.mouseLocation()

--- a/pymouse/windows.py
+++ b/pymouse/windows.py
@@ -39,6 +39,9 @@ class PyMouse(PyMouseMeta):
     def move(self, x, y):
         windll.user32.SetCursorPos(x, y)
 
+    def drag(self, x, y):
+        self.move(x, y)
+
     def position(self):
         pt = POINT()
         windll.user32.GetCursorPos(byref(pt))

--- a/pymouse/x11.py
+++ b/pymouse/x11.py
@@ -49,6 +49,9 @@ class PyMouse(PyMouseMeta):
             fake_input(self.display, X.MotionNotify, x=x, y=y)
             self.display.sync()
 
+    def drag(self, x, y):
+        self.move(x, y)
+
     def position(self):
         coord = self.display.screen().root.query_pointer()._data
         return coord["root_x"], coord["root_y"]


### PR DESCRIPTION
Another bit of code from PyLeapMouse that I'd like to push into PyMouse is dragging (with this and scrolling pushed, PyLeapMouse can be entirely migrated to PyUserInput). On OSX, there is a specific event for when the left mouse is dragged while depressed (in PyLeapMouse, this is called instead of the standard "mouse moved" event when the state of the left mouse button is known to be "pressed"). On Windows and X11 there does not seem to be an equivalent, and a standard "mouse moved" event suffices.

Disclaimer: I don't have OSX, so I don't actually know if this OSX-specific event is actually required for dragging, but if it is then a `drag()` method is necessary in PyMouse.
