### PR TITLE
The PyKeyboardEvent _key_press and _key_release functions in windows.py ...

### DIFF
--- a/pykeyboard/windows.py
+++ b/pykeyboard/windows.py
@@ -228,6 +228,7 @@ class PyKeyboardEvent(PyKeyboardEventMeta):
 
         PyKeyboardEventMeta.__init__(self)
         self.hm = pyHook.HookManager()
+        self.hc = pyHook.HookConstants()
         self.shift_state = 0  # 0 is off, 1 is on
         self.alt_state = 0  # 0 is off, 2 is on
 
@@ -247,13 +248,13 @@ class PyKeyboardEvent(PyKeyboardEventMeta):
 
     def handler(self, reply):
         """Upper level handler of keyboard events."""
-        if reply.Message == pyHook.HookConstants.WM_KEYDOWN:
+        if reply.Message == self.hc.WM_KEYDOWN:
             self._key_press(reply)
-        elif reply.Message == pyHook.HookConstants.WM_KEYUP:
+        elif reply.Message == self.hc.WM_KEYUP:
             self._key_release(reply)
-        elif reply.Message == pyHook.HookConstants.WM_SYSKEYDOWN:
+        elif reply.Message == self.hc.WM_SYSKEYDOWN:
             self._key_press(reply)
-        elif reply.Message == pyHook.HookConstants.WM.SYSKEYUP:
+        elif reply.Message == self.hc.WM_SYSKEYUP:
             self._key_release(reply)
         else:
             print('Keyboard event message unhandled: {0}'.format(reply.Message))
@@ -266,6 +267,7 @@ class PyKeyboardEvent(PyKeyboardEventMeta):
             self.toggle_shift_state()
         if event.GetKey() in ['Menu', 'Lmenu', 'Rmenu']:
             self.toggle_alt_state()
+        self.key_press(event)
         #print('Key Pressed!')
         #print('GetKey: {0}'.format(event.GetKey()))  # Name of the virtual keycode, str
         #print('IsAlt: {0}'.format(event.IsAlt()))  # Was the alt key depressed?, bool
@@ -281,7 +283,7 @@ class PyKeyboardEvent(PyKeyboardEventMeta):
             self.toggle_shift_state()
         if event.GetKey() in ['Menu', 'Lmenu', 'Rmenu']:
             self.toggle_alt_state()
-        self.key_release()
+        self.key_release(event)
         #print('Key Released!')
         #print('GetKey: {0}'.format(event.GetKey()))  # Name of the virtual keycode, str
         #print('IsAlt: {0}'.format(event.IsAlt()))  # Was the alt key depressed?, bool


### PR DESCRIPTION
...did not make calls to the public functions.

HookConstants set as an instance variable, so there's no need for a global pyHook import.
Reasonably tested.
