### PR TITLE
X11 patches

### DIFF
--- a/pykeyboard/x11.py
+++ b/pykeyboard/x11.py
@@ -229,7 +229,7 @@ class PyKeyboardEvent(PyKeyboardEventMeta):
     The PyKeyboardEvent implementation for X11 systems (mostly linux). This
     allows one to listen for keyboard input.
     """
-    def __init__(self, display=None):
+    def __init__(self, capture=False, display=None):
         self.display = Display(display)
         self.display2 = Display(display)
         self.ctx = self.display2.record_create_context(
@@ -263,7 +263,7 @@ class PyKeyboardEvent(PyKeyboardEventMeta):
         #for i in range(len(self.display._keymap_codes)):
         #    print('{0}: {1}'.format(i, self.display._keymap_codes[i]))
 
-        PyKeyboardEventMeta.__init__(self)
+        PyKeyboardEventMeta.__init__(self, capture)
 
     def run(self):
         """Begin listening for keyboard input events."""

--- a/pykeyboard/x11.py
+++ b/pykeyboard/x11.py
@@ -269,7 +269,7 @@ class PyKeyboardEvent(PyKeyboardEventMeta):
         """Begin listening for keyboard input events."""
         self.state = True
         if self.capture:
-            self.display2.screen().root.grab_keyboard(True, X.KeyPressMask | X.KeyReleaseMask, X.GrabModeAsync, X.GrabModeAsync, 0, 0, X.CurrentTime)
+            self.display2.screen().root.grab_keyboard(X.KeyPressMask | X.KeyReleaseMask, X.GrabModeAsync, X.GrabModeAsync, X.CurrentTime)
 
         self.display2.record_enable_context(self.ctx, self.handler)
         self.display2.record_free_context(self.ctx)

--- a/pymouse/base.py
+++ b/pymouse/base.py
@@ -122,3 +122,11 @@ class PyMouseEventMeta(Thread):
     def move(self, x, y):
         """Subclass this method with your move event handler"""
         pass
+
+    def scroll(self, x, y, vertical, horizontal):
+        """
+        Subclass this method with your scroll event handler
+            Vertical: + Up, - Down
+            Horizontal: + Right, - Left
+        """
+        pass

--- a/pymouse/windows.py
+++ b/pymouse/windows.py
@@ -126,9 +126,9 @@ class PyMouseEvent(PyMouseEventMeta):
             self.click(x, y, 3, True)
         elif event.Message == pyHook.HookConstants.WM_MBUTTONUP:
             self.click(x, y, 3, False)
-            
+
         elif event.Message == pyHook.HookConstants.WM_MOUSEWHEEL:
             # event.Wheel is -1 when scrolling down, 1 when scrolling up
-            self.scroll(x,y,event.Wheel)
-        
+            self.scroll(x, y, event.Wheel, 0)
+
         return not self.capture

--- a/pymouse/x11.py
+++ b/pymouse/x11.py
@@ -147,12 +147,12 @@ class PyMouseEvent(PyMouseEventMeta):
 
     def stop(self):
         self.state = False
-        self.display.flush()
-        self.display.record_disable_context(self.ctx)
         self.display.ungrab_pointer(X.CurrentTime)
-        self.display2.flush()
-        self.display2.record_disable_context(self.ctx)
+        self.display.record_disable_context(self.ctx)
+        self.display.flush()
         self.display2.ungrab_pointer(X.CurrentTime)
+        self.display2.record_disable_context(self.ctx)
+        self.display2.flush()
 
     def handler(self, reply):
         data = reply.data

--- a/pymouse/x11.py
+++ b/pymouse/x11.py
@@ -167,8 +167,9 @@ class PyMouseEvent(PyMouseEventMeta):
         while len(data):
             event, data = rq.EventField(None).parse_binary_value(data, self.display.display, None, None)
 
-            if event.type == X.ButtonPress and event.detail in [4, 5, 6, 7]:
-                self.scroll(event.root_x, event.root_y, *button_code_to_scroll_direction(event.detail))
+            if event.detail in [4, 5, 6, 7]:
+                if event.type == X.ButtonPress:
+                    self.scroll(event.root_x, event.root_y, *button_code_to_scroll_direction(event.detail))
             elif event.type == X.ButtonPress:
                 self.click(event.root_x, event.root_y, translate_button_code(event.detail), True)
             elif event.type == X.ButtonRelease:

--- a/pymouse/x11.py
+++ b/pymouse/x11.py
@@ -21,7 +21,17 @@ from Xlib.protocol import rq
 
 from .base import PyMouseMeta, PyMouseEventMeta, ScrollSupportError
 
-button_ids = [None, 1, 3, 2, 4, 5, 6, 7]
+
+def translate_button_code(button):
+    #In X11, the button numbers are: leftclick=1, middleclick=2,
+    #  rightclick=3, scrollup=4, scrolldown=5, scrollleft=6,
+    #  scrollright=7
+    #  For the purposes of the cross-platform interface of PyMouse, we
+    #  invert the button number values of the right and middle buttons
+    if button in [1, 2, 3]:
+        return (None, 1, 3, 2)[button]
+    else:
+        return button
 
 
 class PyMouse(PyMouseMeta):
@@ -32,12 +42,12 @@ class PyMouse(PyMouseMeta):
 
     def press(self, x, y, button=1):
         self.move(x, y)
-        fake_input(self.display, X.ButtonPress, button_ids[button])
+        fake_input(self.display, X.ButtonPress, translate_button_code(button))
         self.display.sync()
 
     def release(self, x, y, button=1):
         self.move(x, y)
-        fake_input(self.display, X.ButtonRelease, button_ids[button])
+        fake_input(self.display, X.ButtonRelease, translate_button_code(button))
         self.display.sync()
 
     def scroll(self, vertical=None, horizontal=None, depth=None):
@@ -70,9 +80,9 @@ in X11. This feature is only available on Mac.')
             self.display.sync()
 
     def drag(self, x, y):
-        fake_input(self.display, X.ButtonPress, button_ids[1])
+        fake_input(self.display, X.ButtonPress, 1)
         fake_input(self.display, X.MotionNotify, x=x, y=y)
-        fake_input(self.display, X.ButtonRelease, button_ids[1])
+        fake_input(self.display, X.ButtonRelease, 1)
         self.display.sync()
 
     def position(self):
@@ -149,14 +159,9 @@ class PyMouseEvent(PyMouseEventMeta):
         while len(data):
             event, data = rq.EventField(None).parse_binary_value(data, self.display.display, None, None)
 
-            #In X11, the button numbers are: leftclick=1, middleclick=2,
-            #  rightclick=3, scrollup=4, scrolldown=5, scrollleft=6,
-            #  scrollright=7
-            #  For the purposes of the cross-platform interface of PyMouse, we
-            #  invert the button number values of the right and middle buttons
             if event.type == X.ButtonPress:
-                self.click(event.root_x, event.root_y, (None, 1, 3, 2, 4, 5, 6, 7)[event.detail], True)
+                self.click(event.root_x, event.root_y, translate_button_code(event.detail), True)
             elif event.type == X.ButtonRelease:
-                self.click(event.root_x, event.root_y, (None, 1, 3, 2, 4, 5, 6, 7)[event.detail], False)
+                self.click(event.root_x, event.root_y, translate_button_code(event.detail), False)
             else:
                 self.move(event.root_x, event.root_y)

--- a/tests/basic.py
+++ b/tests/basic.py
@@ -20,31 +20,31 @@ try:
 
     class event(PyMouseEvent):
         def move(self, x, y):
-            print "Mouse moved to", x, y
+            print("Mouse moved to", x, y)
 
         def click(self, x, y, button, press):
             if press:
-                print "Mouse pressed at", x, y, "with button", button
+                print("Mouse pressed at", x, y, "with button", button)
             else:
-                print "Mouse released at", x, y, "with button", button
+                print("Mouse released at", x, y, "with button", button)
 
     e = event()
     #e.capture = True
     e.start()
 
 except ImportError:
-    print "Mouse events are not yet supported on your platform"
+    print("Mouse events are not yet supported on your platform")
 
 m = PyMouse()
 try:
 	size = m.screen_size()
-	print "size: %s" % (str(size))
+	print("size: %s" % (str(size)))
 
 	pos = (random.randint(0, size[0]), random.randint(0, size[1]))
 except:
 	pos = (random.randint(0, 250), random.randint(0, 250))
 
-print "Position: %s" % (str(pos))
+print("Position: %s" % (str(pos)))
 
 m.move(pos[0], pos[1])
 

--- a/tests/test_unix.py
+++ b/tests/test_unix.py
@@ -6,7 +6,7 @@ install:  Xvfb, Xephyr, PyVirtualDisplay, nose
 on Ubuntu:
 
     sudo apt-get install python-nose
-    sudo apt-get install xvfb 
+    sudo apt-get install xvfb
     sudo apt-get install xserver-xephyr
     sudo apt-get install python-setuptools
     sudo easy_install PyVirtualDisplay
@@ -36,13 +36,21 @@ positions = [
               (0, 0),
               (10, 20),
               (-10, -20),
-              (5, 0),
               (2222, 2222),
+              (5, 0),
               (9, 19),
               ]
 
+buttons = [1, 2, 3, 10]  # 10 = mouse btn6
 
 class Event(PyMouseEvent):
+    def reset(self):
+        self.pos = None
+        self.button = None
+        self.press = None
+        self.scroll_vertical = None
+        self.scroll_horizontal = None
+
     def move(self, x, y):
         print("Mouse moved to", x, y)
         self.pos = (x, y)
@@ -52,6 +60,12 @@ class Event(PyMouseEvent):
             print("Mouse pressed at", x, y, "with button", button)
         else:
             print("Mouse released at", x, y, "with button", button)
+        self.button = button
+        self.press = press
+
+    def scroll(self, x, y, vertical, horizontal):
+        self.scroll_vertical = vertical
+        self.scroll_horizontal = horizontal
 
 def expect_pos(pos, size):
     def expect(x, m):
@@ -79,14 +93,48 @@ class Test(TestCase):
     def test_event(self):
         for size in screen_sizes:
             with Display(visible=VISIBLE, size=size):
-                time.sleep(3)  # TODO: how long should we wait?
+                time.sleep(1.0)  # TODO: how long should we wait?
                 mouse = PyMouse()
                 event = Event()
                 event.start()
+                # check move
                 for p in positions:
-                    event.pos = None
+                    event.reset()
                     mouse.move(*p)
-                    time.sleep(0.1)  # TODO: how long should we wait?
+                    time.sleep(0.01)
                     print('check ', expect_pos(p, size), '=', event.pos)
                     eq_(expect_pos(p, size), event.pos)
-                event.stop()                
+                # check buttons
+                for btn in buttons:
+                    # press
+                    event.reset()
+                    mouse.press(0, 0, btn)
+                    time.sleep(0.01)
+                    print("check button", btn, "pressed")
+                    eq_(btn, event.button)
+                    eq_(True, event.press)
+                    # release
+                    event.reset()
+                    mouse.release(0, 0, btn)
+                    time.sleep(0.01)
+                    print("check button", btn, "released")
+                    eq_(btn, event.button)
+                    eq_(False, event.press)
+                # check scroll
+                def check_scroll(btn, vertical=None, horizontal=None):
+                    event.reset()
+                    mouse.press(0, 0, btn)
+                    time.sleep(0.01)
+                    if vertical:
+                        eq_(vertical, event.scroll_vertical)
+                    elif horizontal:
+                        eq_(horizontal, event.scroll_horizontal)
+                print("check scroll up")
+                check_scroll(4, 1, 0)
+                print("check scroll down")
+                check_scroll(5, -1, 0)
+                print("check scroll left")
+                check_scroll(6, 0, 1)
+                print("check scroll right")
+                check_scroll(7, 0, -1)
+                event.stop()

--- a/tests/test_unix.py
+++ b/tests/test_unix.py
@@ -44,14 +44,14 @@ positions = [
 
 class Event(PyMouseEvent):
     def move(self, x, y):
-        print "Mouse moved to", x, y
+        print("Mouse moved to", x, y)
         self.pos = (x, y)
 
     def click(self, x, y, button, press):
         if press:
-            print "Mouse pressed at", x, y, "with button", button
+            print("Mouse pressed at", x, y, "with button", button)
         else:
-            print "Mouse released at", x, y, "with button", button
+            print("Mouse released at", x, y, "with button", button)
 
 def expect_pos(pos, size):
     def expect(x, m):
@@ -87,6 +87,6 @@ class Test(TestCase):
                     event.pos = None
                     mouse.move(*p)
                     time.sleep(0.1)  # TODO: how long should we wait?
-                    print 'check ', expect_pos(p, size), '=', event.pos
+                    print('check ', expect_pos(p, size), '=', event.pos)
                     eq_(expect_pos(p, size), event.pos)
                 event.stop()                


### PR DESCRIPTION
1. Resolves bug where clicking with Mouse Button 4, 5 (etc.) would produce IndexError.
Currently only x11 supports buttons above 3. So i didin't make any standarization for that - mouse button 4 has key code of 8 etc.
2. Adds wheel event handler
3. Resolves stop() bug #48 
4. grab_keyboard() wrong parameters order #60 
5. Fixed and updated tests for x11.

Let me know if i should change something in this PR.